### PR TITLE
メッセージの送信機能を非同期通信にする

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -34,7 +34,7 @@ $(function(){
     .done(function(data){
       var html = buildData(data);
       $('.messages').append(html);
-      $('#message_content').val('');
+      $('.new_message')[0].reset();
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
     })
     .fail(function(){

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,25 @@
 $(function(){
+  function buildData(data){
+    var html = `<div class="message">
+                <div class="upper-info">
+                  <div class="upper-info__user">
+                     ${data.name}
+                  </div>
+                 <div class="upper-info__date">
+                   ${data.created_at}
+                 </div>
+               </div>
+                <div class="message__text">
+                  <p class="message__text__content">
+                    ${data.content}
+                  </p>
+                </div>
+               </div>`
+    return html;
+  }
+
   $('#new_message').on('submit', function(e){
+    console.log("test")
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action');
@@ -9,7 +29,19 @@ $(function(){
       data: formData,
       dataType: 'json',
       processData: false,
-      contentType: false
+      contentType: false,
+    })
+    .done(function(data){
+      var html = buildData(data);
+      $('.messages').append(html);
+      $('#message_content').val('');
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+    })
+    .fail(function(){
+      alert('error');
+    })
+    .always(function(data){
+      $('.form__submit').prop('disabled', false);
     })
   })
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -13,13 +13,13 @@ $(function(){
                   <p class="message__text__content">
                     ${data.content}
                   </p>
+                  <img class="message__text__image" src=${data.image} alt="Test image">
                 </div>
                </div>`
     return html;
   }
 
   $('#new_message').on('submit', function(e){
-    console.log("test")
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -31,8 +31,8 @@ $(function(){
       processData: false,
       contentType: false,
     })
-    .done(function(data){
-      var html = buildData(data);
+    .done(function(messagedata){
+      var html = buildData(messagedata);
       $('.messages').append(html);
       $('.new_message')[0].reset();
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
@@ -40,7 +40,7 @@ $(function(){
     .fail(function(){
       alert('error');
     })
-    .always(function(data){
+    .always(function(){
       $('.form__submit').prop('disabled', false);
     })
   })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,15 @@
+$(function(){
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+  })
+})

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,7 +8,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'}
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.content @message.content
+json.name @message.user.name
+json.created_at @message.created_at
+

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.content @message.content
 json.name @message.user.name
-json.created_at @message.created_at
-
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.image @message.image.url

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,7 +11,7 @@
           Member
       .edit-btn
         %a(href="")
-          Edit 
+          Edit
     .messages
       = render @messages
     .form

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,8 +10,7 @@
         .member-list
           Member
       .edit-btn
-        %a(href="")
-          Edit
+        = link_to "Edit", edit_group_path(@group)
     .messages
       = render @messages
     .form

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
#What
jsファイルの作成、フォーム送信に合わせてイベントの発火、ajaxの利用。
jbuilderを使用、非同期に失敗した際の処理の実装。
#Why
非同期通信による処理速度の向上のため。
昨日実装による、Ajaxや非同期通信の理解向上のため。