### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,21 +1,23 @@
 $(function(){
-  function buildData(data){
-    var html = `<div class="message">
-                <div class="upper-info">
-                  <div class="upper-info__user">
-                     ${data.name}
-                  </div>
-                 <div class="upper-info__date">
-                   ${data.created_at}
-                 </div>
-               </div>
-                <div class="message__text">
-                  <p class="message__text__content">
-                    ${data.content}
-                  </p>
-                  <img class="message__text__image" src=${data.image} alt="Test image">
-                </div>
-               </div>`
+  
+  function buildHTML(message) {
+    image = (message.image) ? `<img class= "message__text__image" src=${message.image.url} >` : "";
+    var html = `<div class="message" data-message-id="${message.id}"> 
+          <div class="upper-info">
+            <div class="upper-info__user">
+              ${message.user_name}
+            </div>
+            <div class="upper-info__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="meesage__text">
+            <p class="message__text__content">
+              ${message.content}
+            </p>
+            ${image}
+          </div>
+        </div>`
     return html;
   }
 
@@ -32,7 +34,7 @@ $(function(){
       contentType: false,
     })
     .done(function(messagedata){
-      var html = buildData(messagedata);
+      var html = buildHTML(messagedata);
       $('.messages').append(html);
       $('.new_message')[0].reset();
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
@@ -44,4 +46,26 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     })
   })
-})
+
+  var reloadMessages = function() {
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {last_id: last_message_id}
+    })
+    .done(function(messages) {
+      var insertHTML = '';
+      messages.forEach(function (message) {
+        insertHTML = buildHTML(message); 
+      $('.messages').append(insertHTML);
+      });
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })
+    .fail(function() {
+      alert('自動更新に失敗しました');
+    });
+  }
+  setInterval(reloadMessages, 5000);
+});

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+     group = Group.find(params[:group_id])
+     last_message_id = params[:last_id].to_i
+     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .upper-info
     .upper-info__user
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
-json.content @message.content
-json.name @message.user.name
-json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
-json.image @message.image.url
+json.(@message, :content, :image)
+json.created_at @message.created_at
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
メッセージ更新のアクションの定義。追加したアクションのリクエストの実装。
最新のメッセージをブラウザのメッセージ一覧に追加。
メッセージ一覧のページでのみJSが動くよう実装。
#Why
チャット画面が自動で更新されることでチャットのしやすさを上げるため。
また自動更新機能の知識を理解するため。